### PR TITLE
Note that `Backquote` is also called backtick or grave

### DIFF
--- a/index-source.txt
+++ b/index-source.txt
@@ -475,7 +475,7 @@ path: stylesheet-extra.include
 			may be present on a keyboard layout.
 
 			BEGIN_CODE_TABLE alphanumeric-writing-system "List of code values for writing system keys in the Alphanumeric section."
-				CODE Backquote		KEYCAP{`~} on a US keyboard. This is the KEYCAP{半角/全角/漢字}
+				CODE Backquote		KEYCAP{`~} on a US keyboard. This is also called a backtick or grave. This is the KEYCAP{半角/全角/漢字}
 									(PHONETIC{hankaku/zenkaku/kanji}) key on Japanese keyboards
 				CODE Backslash		Used for both the US KEYCAP{\|} (on the 101-key layout) and also for the key
 									located between the KEYCAP{"} and KEYCAP{Enter} keys on row C of the 102-,

--- a/index.html
+++ b/index.html
@@ -767,7 +767,7 @@ miscellaneous <a data-link-type="dfn" href="#function-key" id="ref-for-function-
      <tr>
       <td class="code-table-code"><code class="code" id="code-Backquote">"Backquote"</code>
       <td class="code-table-required">Yes
-      <td><code class="keycap">`~</code> on a US keyboard. This is the <code class="keycap">半角/全角/漢字</code> (<span class="unicode">hankaku/zenkaku/kanji</span>) key on Japanese keyboards 
+      <td><code class="keycap">`~</code> on a US keyboard. This is also called a backtick or grave. This is the <code class="keycap">半角/全角/漢字</code> (<span class="unicode">hankaku/zenkaku/kanji</span>) key on Japanese keyboards 
      <tr>
       <td class="code-table-code"><code class="code" id="code-Backslash">"Backslash"</code>
       <td class="code-table-required">Yes


### PR DESCRIPTION
Nice to have when searching for the other terms in the spec.

I couldn't get the version of `bikeshed` to work properly, so I couldn't get it to update the `document-revision` meta tag :/.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Dec 1, 2024, 11:31 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
🕵️‍♀️  That doesn't seem to be a ReSpec document. Please check manually: http://localhost:8082/uploads/SDAFGO/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2024-12-01
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/uievents-code%2344.)._
</details>
